### PR TITLE
Fix: Added cstdint to arp.hpp

### DIFF
--- a/src/models/arp.hpp
+++ b/src/models/arp.hpp
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <map>
+#include <cstdint>
 
 constexpr int PROTO_ARP = 0x0806;
 constexpr int ETH2_HEADER_LEN = 14;


### PR DESCRIPTION
Tested with Arch Linux which has the following `make` and `gcc` version.
- `GNU Make 4.4.1`
- `GCC 13.1.1 20230429`

When installing, `make` program shows this.
```
mkdir -p bin/models

g++ src/models/scanner.cpp -c -o bin/models/scanner.o -Wall -Wextra -O2 -std=c++17 -I src/

In file included from src/models/scanner.cpp:3:
src/models/arp.hpp:38:65: error: 'uint32_t' does not name a type
    38 | struct sockaddr_ll prepare_arp(unsigned char *buffer, const uint32_t &dst_ip, Operation op=Operation::REQUEST,
       | ^~~~~~~~
src/models/arp.hpp:1:1: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
   +++ |+#include <cstdint>
     1 | #ifndef _ARP_HPP
src/models/arp.hpp:39:74: error: 'uint32_t' does not name a type
    39 | const std::string &dst_mac="", const uint32_t &src_ip=0, const std::string &src_mac="") const;
       | ^~~~~~~~
src/models/arp.hpp:39:74: note: 'uint32_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?

make: *** [Makefile:17: bin/models/scanner.o] Error 1
```

Then I fixed it by following the instructions given by the program output and it ran perfectly after.