### PR TITLE
models/scanner: fix nullptr deref

### DIFF
--- a/src/models/scanner.cpp
+++ b/src/models/scanner.cpp
@@ -11,6 +11,10 @@
 #include <arpa/inet.h>
 
 bool NetworkScanner::is_network(const struct ifaddrs *ifaddr) const {
+    if (ifaddr->ifa_addr == NULL) {
+        return false;
+    }
+
     sa_family_t family = ifaddr->ifa_addr->sa_family;
     unsigned int flags = ifaddr->ifa_flags;
     bool is_up = (flags & IFF_UP) != 0;


### PR DESCRIPTION
According to ASAN:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==20196==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x556abff4794a bp 0x7ffe9dbacb90 sp 0x7ffe9dbacb40 T0)
==20196==The signal is caused by a READ memory access.
==20196==Hint: address points to the zero page.
    #0 0x556abff4794a in NetworkScanner::is_network(ifaddrs const*) const /home/rupansh/NetCut/src/models/scanner.cpp:14:44
    #1 0x556abff48f3b in NetworkScanner::scan_networks() /home/rupansh/NetCut/src/models/scanner.cpp:101:13
    #2 0x556abff6f0c0 in Controller::scan_targets() /home/rupansh/NetCut/src/models/controller.cpp:15:46
    #3 0x556abff6f55e in Controller::show_targets() /home/rupansh/NetCut/src/models/controller.cpp:22:5
    #4 0x556abff45bb2 in main /home/rupansh/NetCut/src/main.cpp:8:20
    #5 0x7f3077227ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 316d0d3666387f0e8fb98773f51aa1801027c5ab)
    #6 0x7f3077227d89 in __libc_start_main (/usr/lib/libc.so.6+0x27d89) (BuildId: 316d0d3666387f0e8fb98773f51aa1801027c5ab)
    #7 0x556abfe0c6e4 in _start (/home/rupansh/NetCut/bin/main+0x216e4) (BuildId: 1a36707c7f82154a2d8c28f2550dbed951c6943c)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/rupansh/NetCut/src/models/scanner.cpp:14:44 in NetworkScanner::is_network(ifaddrs const*) const
==20196==ABORTING
```